### PR TITLE
Code Update: Host ApplyTime support

### DIFF
--- a/activation.hpp
+++ b/activation.hpp
@@ -3,6 +3,7 @@
 #include "config.h"
 
 #include "org/openbmc/Associations/server.hpp"
+#include "utils.hpp"
 #include "xyz/openbmc_project/Software/ActivationProgress/server.hpp"
 #include "xyz/openbmc_project/Software/ExtendedVersion/server.hpp"
 #include "xyz/openbmc_project/Software/RedundancyPriority/server.hpp"
@@ -31,6 +32,19 @@ using RedundancyPriorityInherit = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Software::server::RedundancyPriority>;
 using ActivationProgressInherit = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Software::server::ActivationProgress>;
+
+constexpr auto applyTimeImmediate =
+    "xyz.openbmc_project.Software.ApplyTime.RequestedApplyTimes.Immediate";
+constexpr auto applyTimeIntf = "xyz.openbmc_project.Software.ApplyTime";
+constexpr auto dbusPropIntf = "org.freedesktop.DBus.Properties";
+constexpr auto applyTimeObjPath = "/xyz/openbmc_project/software/apply_time";
+constexpr auto applyTimeProp = "RequestedApplyTime";
+
+constexpr auto hostStateIntf = "xyz.openbmc_project.State.Host";
+constexpr auto hostStateObjPath = "/xyz/openbmc_project/state/host0";
+constexpr auto hostStateRebootProp = "RequestedHostTransition";
+constexpr auto hostStateRebootVal =
+    "xyz.openbmc_project.State.Host.Transition.Reboot";
 
 namespace sdbusRule = sdbusplus::bus::match::rules;
 
@@ -267,6 +281,20 @@ class Activation : public ActivationInherit
      * @returns Activations - The activation value
      */
     using ActivationInherit::activation;
+
+    /**
+     * @brief Determine the configured image apply time value
+     *
+     * @return true if the image apply time value is immediate
+     **/
+    bool checkApplyTimeImmediate();
+
+    /**
+     * @brief Reboot the Host. Called when ApplyTime is immediate.
+     *
+     * @return none
+     **/
+    void rebootHost();
 
   protected:
     /** @brief Check if systemd state change is relevant to this object

--- a/ubi/activation_ubi.cpp
+++ b/ubi/activation_ubi.cpp
@@ -4,6 +4,7 @@
 #include "serialize.hpp"
 
 #include <experimental/filesystem>
+#include <phosphor-logging/log.hpp>
 
 namespace openpower
 {
@@ -13,6 +14,7 @@ namespace updater
 {
 namespace fs = std::experimental::filesystem;
 namespace softwareServer = sdbusplus::xyz::openbmc_project::Software::server;
+using namespace phosphor::logging;
 
 uint8_t RedundancyPriorityUbi::priority(uint8_t value)
 {
@@ -65,6 +67,12 @@ auto ActivationUbi::activation(Activations value) -> Activations
                 (fs::is_directory(PNOR_RO_PREFIX + versionId)))
             {
                 finishActivation();
+                if (Activation::checkApplyTimeImmediate())
+                {
+                    log<level::INFO>("Image Active. ApplyTime is immediate, "
+                                     "rebooting Host.");
+                    Activation::rebootHost();
+                }
                 return softwareServer::Activation::activation(
                     softwareServer::Activation::Activations::Active);
             }


### PR DESCRIPTION
Get the requested image apply time value provided through the
UpdateService redfish schema. If the apply time value is Immediate, then
host reboot will be triggered just after the new pnor image activation. The
default apply time value is OnReset in which the new image remains at
Active state and user has to manualy reboot the host for applying the new
image.

Tested: Verified that host is getting rebooted while doing a pnor code update
if the apply time value is Immediate.  Tested this use case at server power Off
and Running scenarios. OnReset scenario was also tested in which new image
remained at Active state as pnor code update application did not trigger the
host reboot.

Note: This change is applicable to ubi based systems (Witherspoon)

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: Id1eb954935fa3e9c6c92be7f3278979b4cb1fb88