### PR TITLE
op-pnor-msl.service: Remove RemainAfterExit

### DIFF
--- a/op-pnor-msl.service
+++ b/op-pnor-msl.service
@@ -5,7 +5,6 @@ After=obmc-flash-bios-updatesymlinks.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/openpower-pnor-msl
-RemainAfterExit=yes
 
 [Install]
 WantedBy=obmc-flash-bios-updatesymlinks.service


### PR DESCRIPTION
The minimum ship level check should run on every power on attempt.
By having the RemainAfterExit=yes, the service only runs once.
Remove it so that it runs on every power on.

Tested: Removing this line allows the service to start every time
        that obmc-flash-bios-updatesymlinks.service is started.

Change-Id: Ia2a31246ac6575d68329c498218613986bb3c0bc
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>