### PR TITLE
ubi: reset: Preserve the SECBOOT partition

### DIFF
--- a/ubi/item_updater_ubi.cpp
+++ b/ubi/item_updater_ubi.cpp
@@ -232,11 +232,17 @@ void ItemUpdaterUbi::reset()
         }
     }
 
-    // Clear the preserved partition.
+    // Clear the preserved partition, except for SECBOOT that contains keys
+    // provisioned for the system.
     if (fs::is_directory(PNOR_PRSV))
     {
         for (const auto& iter : fs::directory_iterator(PNOR_PRSV))
         {
+            auto secbootPartition = "SECBOOT";
+            if (iter.path().stem() == secbootPartition)
+            {
+                continue;
+            }
             fs::remove_all(iter);
         }
     }


### PR DESCRIPTION
With the implementation of secure boot in Power9, skiboot requires the
SECBOOT partition to be preserved during factory resets, because it
contains keys provisioned for the system that cannot be recreated (are
not part of the read-only image).

Tested: Verified that the SECBOOT partition file is preserved after a
factory reset:

root@witherspoon:~# ls -l
/var/lib/phosphor-software-manager/pnor/prsv/
-rw-rw-r--    1 root     root        294912 Sep 27 20:21 CVPD
-rw-rw-r--    1 root     root        294912 Sep 27 20:23 DJVPD
-rw-rw-r--    1 root     root        589824 Sep 27 20:21 MVPD
-rw-rw-r--    1 root     root        589824 Sep 27 20:25 NVRAM
-rw-r--r--    1 root     root        147456 Sep 27 20:26 SECBOOT

root@witherspoon:~# busctl call
org.open_power.Software.Host.Updater /xyz/openbmc_project/software
xyz.openbmc_project.Common.FactoryReset Reset

root@witherspoon:~# ls -l
/var/lib/phosphor-software-manager/pnor/prsv/
-rw-r--r--    1 root     root        147456 Sep 27 20:26 SECBOOT

Change-Id: I762d03c937e8e4eff2f87aa087e6152a302180b2
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>