### PR TITLE
Expose HBB lid over PCIe space

### DIFF
--- a/hbb-lid-mmio.cpp
+++ b/hbb-lid-mmio.cpp
@@ -1,0 +1,176 @@
+#include "config.h"
+
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <exception>
+#include <expected>
+#include <filesystem>
+#include <format>
+#include <fstream>
+
+constexpr auto DEVICE_PATH = "/dev/bmc-device0";
+
+// DEVICE_OFFSET is the starting offset 64MB MMIO region of PCIe address space
+// available for use.
+constexpr auto DEVICE_OFFSET = 0x3D00000;
+constexpr auto LID_FILE = "81e0065a.lid";
+
+/**
+ * @brief Safe wrapper around mmap syscall
+ *
+ * MMIO provide RAII managed safe wrapper to fixed side memory
+ * regions to perform read and write operating on that region.
+ *
+ *
+ * @details
+ * MMIO take **ownership** of provided region and responsible for unmapping the
+ * region.
+ * MMIO can't be copied or assigned.
+ *
+ */
+class MMIO
+{
+  public:
+    MMIO(uintptr_t address, size_t size) : address{address}, size{size} {}
+
+    MMIO(const MMIO&) = delete;
+
+    MMIO& operator=(const MMIO&) = delete;
+
+    ~MMIO()
+    {
+        if (address)
+        {
+            munmap(reinterpret_cast<void*>(address), size);
+        }
+    }
+
+    /**
+     * @brief write the data of file to MMIO region.
+     *
+     * @details
+     * Size of the file should be exactly same with the MMIO region size.
+     * file is expected the be binay and have read permission.
+     *
+     * @param path path to input file
+     */
+    auto write_file(const std::filesystem::path& path) -> void
+    {
+        const auto file_size = std::filesystem::file_size(path);
+        if (file_size != size)
+        {
+            throw std::runtime_error(
+                std::format("MMIO size({}) != file_size({})", size, file_size));
+        }
+
+        std::ifstream reader(path, std::ios_base::binary);
+        if (!reader.good())
+        {
+            throw std::system_error(errno, std::system_category());
+        }
+
+        reader.read(reinterpret_cast<char*>(address), file_size * sizeof(char));
+    }
+
+    auto dump(const std::filesystem::path& path) -> void
+    {
+        std::ofstream writer(path, std::ios_base::binary);
+        if (!writer.is_open())
+        {
+            throw std::system_error(errno, std::system_category());
+        }
+        writer.write(reinterpret_cast<const char*>(address), size);
+    }
+
+  private:
+    uintptr_t address{0};
+    size_t size{0};
+};
+
+/**
+ * @brief Safe wrapper to manage MMIO devices
+ *
+ * Device provide RAII managed wrapper to device file descriptor to manage and
+ * access MMIO regions for the file descriptor
+ *
+ * @details
+ * Device optionally take the ownership of file descriptor but can be managed
+ * manually. Device can't be copied or assigned.
+ *
+ */
+class Device
+{
+  public:
+    Device(int fd, bool managed = false) : fd{fd}, managed{managed} {}
+
+    Device(const Device&) = delete;
+
+    Device& operator=(const Device&) = delete;
+
+    ~Device()
+    {
+        if (fd != -1 && managed)
+        {
+            close(fd);
+        }
+    }
+
+    /**
+     * @brief Get the MMIO region of device node.
+     *
+     * @param offset offset of MMIO region
+     * @param size size of MMIO region
+     * @return MMIO managed MMIO object
+     */
+    auto get_region(off_t offset, size_t size) -> MMIO
+    {
+        auto mem =
+            mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, offset);
+        if (!mem)
+        {
+            throw std::system_error(errno, std::system_category());
+        }
+        return MMIO(reinterpret_cast<uintptr_t>(mem), size);
+    }
+
+    /**
+     * @brief open the managed device node in read+write permission
+     *
+     * @param devnode_path path to device file descriptor
+     * @return Device managed Device object
+     */
+    static auto open_path(const std::filesystem::path& devnode_path) -> Device
+    {
+        auto fd = open(devnode_path.c_str(), O_RDWR | O_CLOEXEC);
+        if (fd == -1)
+        {
+            throw std::system_error(errno, std::system_category());
+        }
+        return Device(fd, true);
+    }
+
+  private:
+    int fd{-1};
+    bool managed{false};
+};
+
+int main(int, char**)
+{
+    auto bmc_device = Device::open_path(DEVICE_PATH);
+    auto lid_path = std::filesystem::path(FIRMWARE_PATCH_PATH) / LID_FILE;
+    if (!std::filesystem::exists(lid_path))
+    {
+        lid_path = std::filesystem::path(FIRMWARE_PATH) / LID_FILE;
+    }
+
+    const auto lid_size = std::filesystem::file_size(lid_path);
+
+    auto memory = bmc_device.get_region(DEVICE_OFFSET, lid_size);
+    memory.write_file(lid_path);
+
+    return 0;
+}

--- a/hbb-lid-mmio.service
+++ b/hbb-lid-mmio.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=HBB Lid Inject
+After=openpower-update-bios-attr-table.service
+Wants=openpower-update-bios-attr-table.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/hbb-lid-mmio
+
+[Install]
+WantedBy=pldmd.service

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,8 @@ extra_scripts = []
 build_vpnor = get_option('vpnor').allowed()
 build_pldm = get_option('pldm').allowed()
 build_verify_signature = get_option('verify-signature').allowed()
+firmware_path = get_option('firmware-path')
+firmware_patch_path = get_option('firmware-patch-path')
 
 if not cxx.has_header('CLI/CLI.hpp')
     error('Could not find CLI.hpp')
@@ -108,6 +110,8 @@ subs.set_quoted('UPDATEABLE_FWD_ASSOCIATION', 'updateable')
 subs.set_quoted('UPDATEABLE_REV_ASSOCIATION', 'software_version')
 subs.set_quoted('VERSION_IFACE', 'xyz.openbmc_project.Software.Version')
 subs.set('WANT_SIGNATURE_VERIFY', build_verify_signature)
+subs.set_quoted('FIRMWARE_PATH', firmware_path)
+subs.set_quoted('FIRMWARE_PATCH_PATH', firmware_patch_path)
 configure_file(output: 'config.h', configuration: subs)
 
 if get_option('device-type') == 'ubi'
@@ -202,6 +206,8 @@ executable(
     install: true,
 )
 
+executable('hbb-lid-mmio', ['hbb-lid-mmio.cpp'], install: true)
+
 fs = import('fs')
 foreach s : extra_scripts
     fs.copyfile(
@@ -215,6 +221,7 @@ endforeach
 unit_files = [
     'op-pnor-msl.service',
     'org.open_power.Software.Host.Updater.service',
+    'hbb-lid-mmio.service',
 ] + extra_unit_files
 
 systemd_system_unit_dir = dependency('systemd').get_variable(

--- a/meson.options
+++ b/meson.options
@@ -19,3 +19,15 @@ option(
     description: 'Enable image signature validation',
 )
 option('msl', type: 'string', description: 'Minimum Ship Level')
+option(
+    'firmware-path',
+    type: 'string',
+    value: '/media/hostfw/running/',
+    description: 'Firmware path',
+)
+option(
+    'firmware-patch-path',
+    type: 'string',
+    value: '/usr/local/share/hostfw/running/',
+    description: 'Firmware patch path',
+)


### PR DESCRIPTION
Created a service to load the Host Boot Bootloader lid file on to the
memory mapped region of PCIe address space.Hostboot need the HBB lid
file to be loaded during the initial boot. Currently mbox is used to
transfer the HBB lid file to hostboot. Going forward we are planning to
deprecate Mbox and use Memory mapped PCIe address space for the HBB lid.
This address is provided to to the host to load the file.

Tested: Verified the sha256 hash of raw memory region of exposed lid
file at required address via /dev/mem with the original lid file.