### PR TITLE
1120: add function mmc_get_primary_label to update logic for bootside check

### DIFF
--- a/mmc/obmc-flash-bios
+++ b/mmc/obmc-flash-bios
@@ -16,6 +16,23 @@ bios_reset_if_needed() {
     fi
 }
 
+mmc_get_primary_label() {
+    # Get root device /dev/mmcblkpX
+    rootmatch=" on / "
+    root="$(mount | grep "${rootmatch}")"
+    # shellcheck disable=SC2295
+    root="${root%${rootmatch}*}"
+
+    # Find the device label
+    if [ "$(readlink -f /dev/disk/by-partlabel/rofs-a)" = "${root}" ]; then
+        echo "a"
+    elif [ "$(readlink -f /dev/disk/by-partlabel/rofs-b)" = "${root}" ]; then
+        echo "b"
+    else
+        echo ""
+    fi
+}
+
 mmc_init() {
     base_dir="/media/hostfw"
     ro_dir="${base_dir}/running-ro"
@@ -42,7 +59,7 @@ mmc_init() {
 
     # Mount the image that corresponds to the boot label as read-only to be used
     # to populate the running directory.
-    boot_label="$(fw_printenv -n bootside)"
+    boot_label="$(mmc_get_primary_label)"
     if ! grep -q "${ro_dir}" /proc/mounts; then
         mount ${base_dir}/hostfw-"${boot_label}" ${ro_dir} -o ro
     fi
@@ -129,7 +146,7 @@ mmc_patch() {
         return 0
     fi
 
-    boot_label="$(fw_printenv -n bootside)"
+    boot_label="$(mmc_get_primary_label)"
     if [ "${boot_label}" = "a" ]; then
         alternate_label="b"
     else


### PR DESCRIPTION
#### add function mmc_get_primary_label to update logic for bootside check
```
Currently bootside is used to mount rofs but if BMC fails to boot the
bootside env variable is not updated properly. This fix changes the
logic of checking the bootside to properly mount rofs regardless of
bootside value.

Tested: Tested by corrupting kernel then performing a system reboot.
Checking the fw_printenv output for bootside and comparing with the
outputs of df and mount shows that this fix mounts the correct bootside
regardless of the bootside env variable value.

Change-Id: I99bcf5e5abc4483b010cccb1c47082948e096ec1
Signed-off-by: Bryon Catlin <bryon.catlin@gmail.com>
```