### PR TITLE
mmc: Ignore recover_pnor_files bin failures

### DIFF
--- a/mmc/obmc-recover-pnor.service
+++ b/mmc/obmc-recover-pnor.service
@@ -7,7 +7,7 @@ After=openpower-update-bios-attr-table.service
 [Service]
 RemainAfterExit=yes
 Type=oneshot
-ExecStart=/usr/bin/recover_pnor_files
+ExecStart=-/usr/bin/recover_pnor_files
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Prefix ExecStart with - in obmc-recover-pnor.service to ignore failures from recover_pnor_files.

The binary issues a D-Bus call to create a dump, which can fail in low disk space conditions. Such failures should not cause the systemd unit to fail or block boot.