### PR TITLE
1210: Add Huygens system

### DIFF
--- a/item_updater_main.cpp
+++ b/item_updater_main.cpp
@@ -72,12 +72,16 @@ int main(int argc, char* argv[])
         {"com.ibm.Hardware.Chassis.Model.Bonnell"s, {".BONNELL_XML"s, ".P10"s}},
         {"com.ibm.Hardware.Chassis.Model.Everest"s, {".EVEREST_XML"s, ".P10"s}},
         {"com.ibm.Hardware.Chassis.Model.Fuji"s, {".FUJI_XML"s, ".P10"s}},
+        {"com.ibm.Hardware.Chassis.Model.Huygens"s,
+         {".RAINIER_2U_XML"s, ".P10"s}},
         {"com.ibm.Hardware.Chassis.Model.Rainier2U"s,
          {".RAINIER_2U_XML"s, ".P10"s}},
         {"com.ibm.Hardware.Chassis.Model.Rainier4U"s,
          {".RAINIER_4U_XML"s, ".P10"s}},
         {"com.ibm.Hardware.Chassis.Model.Rainier1S4U"s,
          {".RAINIER_4U_XML"s, ".P10"s}},
+        {"com.ibm.Hardware.Chassis.Model.RBMCPrototype"s,
+         {".RAINIER_2U_XML"s, ".P10"s}},
     }};
 
     // subcommandContext allows program subcommand callbacks to add loop event


### PR DESCRIPTION
Add the Huygens systems based on EM commit:
```
https://github.com/openbmc/entity-manager/commit/4a3e63937059119f29e42dfd45eeb970bed77ef5
```

Initially map the Huygens files to the Rainier and P10 ones as the Huygens files are not defined yet.