### PR TITLE
Fix nested /running directory creation

### DIFF
--- a/mmc/obmc-flash-bios
+++ b/mmc/obmc-flash-bios
@@ -177,7 +177,13 @@ mmc_patch() {
     if [ "$(readlink -f "${symlink_base}/pnor")" != "${running_patch_dir}" ]; then
         ln -s "${running_patch_dir}" "${symlink_base}/pnor"
     fi
-    if [ "$(readlink -f "${hostfw_symlink_base}/running")" != "${running_patch_dir}" ]; then
+    # Check if path exists and remove it (whether it's a symlink or directory)
+    if [ -e "${hostfw_symlink_base}/running" ] || [ -L "${hostfw_symlink_base}/running" ]; then
+        if [ "$(readlink -f "${hostfw_symlink_base}/running")" != "${running_patch_dir}" ]; then
+            rm -rf "${hostfw_symlink_base}/running"
+        fi
+    fi
+    if [ ! -e "${hostfw_symlink_base}/running" ]; then
         ln -s "${running_patch_dir}" "${hostfw_symlink_base}/running"
     fi
     if [ "$(readlink -f "${hostfw_symlink_base}/alternate")" != "${alternate_patch_dir}" ]; then

--- a/vpnor/obmc-vpnor-util
+++ b/vpnor/obmc-vpnor-util
@@ -101,8 +101,13 @@ function update_symlinks() {
             mkdir -p "${HOSTFW_ACTIVE_PATH}"
         fi
         # Symlinks used by PLDM
-        if [[ $(readlink -f "${HOSTFW_RUNNING_PATH}") != "${MMC_RUNNING_PATH}" ]]; then
-            rm -f ${HOSTFW_RUNNING_PATH}
+        # Check if path exists and remove it (whether it's a symlink or directory)
+        if [ -e "${HOSTFW_RUNNING_PATH}" ] || [ -L "${HOSTFW_RUNNING_PATH}" ]; then
+            if [[ $(readlink -f "${HOSTFW_RUNNING_PATH}") != "${MMC_RUNNING_PATH}" ]]; then
+                rm -rf ${HOSTFW_RUNNING_PATH}
+            fi
+        fi
+        if [ ! -e "${HOSTFW_RUNNING_PATH}" ]; then
             ln -sfv ${MMC_RUNNING_PATH} ${HOSTFW_RUNNING_PATH}
         fi
         if [[ $(readlink -f "${HOSTFW_ALTERNATE_PATH}") != "${MMC_ALTERNATE_PATH}" ]]; then


### PR DESCRIPTION
When files/directories are manually created, a nested /running directory is created under /var/lib/phosphor-software-manager/ hostfw/running. This fix checks if a path exists before creating the symlink and removes it if necessary.

Tested: Verified there is no nested /running directory after modifying the symlink or creating new files via SIMICS.